### PR TITLE
Add wipe-modules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [pkg-dir-cli](https://github.com/sindresorhus/pkg-dir-cli) - Find the root directory of a npm package.
 - [npm-check-updates](https://github.com/tjunnone/npm-check-updates) - Find newer versions of package dependencies than what your package.json allows.
 - [updates](https://github.com/silverwind/updates) - Flexible npm dependency update tool.
-- [wipe-modules](https://github.com/bntzio/wipe-modules) - Easily remove the node_modules folder of non-active projects.
+- [wipe-modules](https://github.com/bntzio/wipe-modules) - Remove node_modules of inactive projects.
 
 ### Boilerplate
 

--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [pkg-dir-cli](https://github.com/sindresorhus/pkg-dir-cli) - Find the root directory of a npm package.
 - [npm-check-updates](https://github.com/tjunnone/npm-check-updates) - Find newer versions of package dependencies than what your package.json allows.
 - [updates](https://github.com/silverwind/updates) - Flexible npm dependency update tool.
-- [wipe-modules](https://github.com/bntzio/wipe-modules) - Remove node_modules of inactive projects.
+- [wipe-modules](https://github.com/bntzio/wipe-modules) - Remove `node_modules` of inactive projects.
 
 ### Boilerplate
 

--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [pkg-dir-cli](https://github.com/sindresorhus/pkg-dir-cli) - Find the root directory of a npm package.
 - [npm-check-updates](https://github.com/tjunnone/npm-check-updates) - Find newer versions of package dependencies than what your package.json allows.
 - [updates](https://github.com/silverwind/updates) - Flexible npm dependency update tool.
+- [wipe-modules](https://github.com/bntzio/wipe-modules) - Easily remove the node_modules folder of non-active projects.
 
 ### Boilerplate
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/bntzio/wipe-modules

**Description:** Easily remove the `node_modules` folder of non-active projects.

**Why you think it's awesome:** [wipe-modules 🗑️](https://github.com/bntzio/wipe-modules) is a CLI tool to delete all the `node_modules` of your projects at once, allowing you to get back a decent amount of hard-disk space.

